### PR TITLE
Provide more control over row and page indexes

### DIFF
--- a/tabitha-core/src/main/java/com/widen/tabitha/reader/BlankRowReader.java
+++ b/tabitha-core/src/main/java/com/widen/tabitha/reader/BlankRowReader.java
@@ -1,0 +1,51 @@
+package com.widen.tabitha.reader;
+
+import com.widen.tabitha.Variant;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Decorates another reader, emitting blank rows whenever a row index is skipped by the inner reader.
+ */
+public class BlankRowReader implements RowReader {
+    private final RowReader inner;
+    private long pageIndex = -1;
+    private long index = 0;
+    private Row nextRow;
+
+    BlankRowReader(RowReader inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Optional<Row> read() throws IOException {
+        // Get the next row if we don't have one.
+        if (nextRow == null) {
+            nextRow = inner.read().orElse(null);
+        }
+
+        // End of stream.
+        if (nextRow == null) {
+            return Optional.empty();
+        }
+
+        // Reset index on page change.
+        if (nextRow.pageIndex() != pageIndex) {
+            index = 0;
+        }
+
+        pageIndex = nextRow.pageIndex();
+
+        // If this is the next sequential row index, return it.
+        if (nextRow.index() == index) {
+            index++;
+            Row row = nextRow;
+            nextRow = null;
+            return Optional.of(row);
+        }
+
+        // Return a blank "padding" row.
+        return Optional.of(new Row(pageIndex, index++, new Variant[0]));
+    }
+}

--- a/tabitha-core/src/main/java/com/widen/tabitha/reader/Header.java
+++ b/tabitha-core/src/main/java/com/widen/tabitha/reader/Header.java
@@ -1,5 +1,7 @@
 package com.widen.tabitha.reader;
 
+import lombok.EqualsAndHashCode;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -11,6 +13,7 @@ import java.util.Optional;
 /**
  * Defines an ordered list of named columns.
  */
+@EqualsAndHashCode
 public class Header implements Iterable<String> {
     // Ordered list of columns.
     private final List<String> columnsByIndex;

--- a/tabitha-core/src/main/java/com/widen/tabitha/reader/IndexNormalizerReader.java
+++ b/tabitha-core/src/main/java/com/widen/tabitha/reader/IndexNormalizerReader.java
@@ -1,0 +1,34 @@
+package com.widen.tabitha.reader;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Decorates another reader and normalizes page and row indexes to always be sequential.
+ */
+public class IndexNormalizerReader implements RowReader {
+    private final RowReader inner;
+    private long lastPage = -1;
+    private long pageIndex = -1;
+    private long index = 0;
+
+    IndexNormalizerReader(RowReader inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public Optional<Row> read() throws IOException {
+        return inner.read().map(row -> {
+            if (row.pageIndex() != lastPage) {
+                lastPage = row.pageIndex();
+                pageIndex++;
+                index = 0;
+            }
+            else {
+                index++;
+            }
+
+            return row.withPageIndex(pageIndex).withIndex(index);
+        });
+    }
+}

--- a/tabitha-core/src/main/java/com/widen/tabitha/reader/InlineHeaderReader.java
+++ b/tabitha-core/src/main/java/com/widen/tabitha/reader/InlineHeaderReader.java
@@ -20,7 +20,7 @@ public class InlineHeaderReader implements RowReader {
         return reader;
     }
 
-    public InlineHeaderReader(RowReader inner) {
+    private InlineHeaderReader(RowReader inner) {
         this.inner = inner;
     }
 
@@ -46,7 +46,7 @@ public class InlineHeaderReader implements RowReader {
                 continue;
             }
 
-            return row.map(r -> r.withHeader(currentHeader).withIndex(r.index() - 1));
+            return row.map(r -> r.withHeader(currentHeader));
         }
     }
 

--- a/tabitha-core/src/main/java/com/widen/tabitha/reader/RowReader.java
+++ b/tabitha-core/src/main/java/com/widen/tabitha/reader/RowReader.java
@@ -119,6 +119,28 @@ public interface RowReader extends Iterable<Row>, Closeable {
     Optional<Row> read() throws IOException;
 
     /**
+     * Create a new row reader that emits rows from this reader with its indexes normalized to be sequential.
+     * <p>
+     * The page index and row index of each row emitted will be changed to be sequential. For example, if the inner row
+     * reader emits a row with indexes 0, 1, 2, and 5, the normalizer will change the indexes to be 0, 1, 2, and 3. The
+     * same normalizing is done on the page indexes. Data in the rows will not be changed.
+     *
+     * @return A new row reader.
+     */
+    default RowReader withSequentialIndexes() {
+        return new IndexNormalizerReader(this);
+    }
+
+    /**
+     * Create a new row reader that fills gaps between rows with blank rows.
+     *
+     * @return A new row reader.
+     */
+    default RowReader withBlankRows() {
+        return new BlankRowReader(this);
+    }
+
+    /**
      * Convert this reader into a reactive stream of rows.
      *
      * @return A reactive stream of rows.


### PR DESCRIPTION
* Change the inline headers option to not alter page indexes from the source file.
* Add a `withSequentialIndexes()` method to `RowReader`, which rewrites the index numbers to be sequential, regardless of the source file.
* Add a `withBlankRows()` method to `RowReader`, which returns blank rows whenever the source file skips indexes.

Fixes #25.